### PR TITLE
feat: add --version CLI flag

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,11 +4,17 @@ import sys
 import threading
 import time
 from argparse import ArgumentParser
+from importlib.metadata import PackageNotFoundError, version
 
 from enumerators.Modules import Modules
 from modules.Module import Module
 from modules.dns.DnsModule import DnsModule
 from modules.tls.TlsModule import TlsModule
+
+try:
+    __version__ = version("dpyproxy")
+except PackageNotFoundError:
+    __version__ = "2.1.0"
 
 
 def extract_activated_modules(parser: ArgumentParser) -> list[Module]:
@@ -20,6 +26,10 @@ def extract_activated_modules(parser: ArgumentParser) -> list[Module]:
 
     general.add_argument('-h', '--help', action='help',
                          help='Show this help message and exit')
+
+    general.add_argument('--version', action='version',
+                         version=f'%(prog)s {__version__}',
+                         help='Show program version and exit')
 
     general.add_argument('--debug',
                          default=False,


### PR DESCRIPTION
## Summary
Add a `--version` flag to the CLI so users can check the installed dpyproxy version without running the proxy.

## Why this matters
Issue #23 requested a simple version flag on the CLI. `main.py` already had a `Standard options` group built via `argparse.add_argument_group('Standard options')` with `-h/--help` but no version output. `pyproject.toml` already declares `version = "2.1.0"`, so the version exists - it just wasn't reachable from the command line.

## Changes
- `main.py`: import `version`/`PackageNotFoundError` from `importlib.metadata`; derive `__version__` from the installed package (`version("dpyproxy")`) with a `"2.1.0"` fallback when metadata is unavailable (editable checkout without build).
- `main.py`: add `--version` to the existing `Standard options` group using `action='version'` so argparse handles print-and-exit automatically, alongside `--help`.

## Testing
```
$ python main.py --version
main.py 2.1.0
$ python main.py --help
...
Standard options:
  -h, --help            Show this help message and exit
  --version             Show program version and exit
  --debug, --no-debug   Turns on debugging
...
```

Fixes #23

This contribution was developed with AI assistance (Codex).
